### PR TITLE
Added cache Worker Manager to handle cache update

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=src
-sonar.exclusions=src/api-docs/**, src/app-server.js, src/helpers/timed-match/match-proc.js
+sonar.exclusions=src/api-docs/**, src/app-server.js, src/helpers/timed-match/match-proc.js, src/helpers/cache/worker.js
 sonar.tests=tests
 sonar.language=js
 

--- a/src/helpers/cache/worker-manager.js
+++ b/src/helpers/cache/worker-manager.js
@@ -1,0 +1,163 @@
+import { Worker } from 'node:worker_threads';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const EVENT_TYPE = {
+    START: 'start',
+    STARTED: 'started',
+    STOP: 'stop',
+    STOPPED: 'stopped',
+    READY: 'ready',
+    CACHE_UPDATES: 'cache-updates',
+    REQUEST_CACHE_VERSION: 'request-cache-version',
+    CACHE_VERSION_RESPONSE: 'cache-version-response',
+    ERROR: 'error'
+};
+
+export const STATUS_TYPE = {
+    RUNNING: 'running',
+    STOPPED: 'stopped',
+    STOPPING: 'stopping',
+    ERROR: 'error'
+};
+
+export class CacheWorkerManager {
+    DEFAULT_INTERVAL = 5000;
+
+    constructor(options = {}) {
+        this.worker = null;
+        this.status = STATUS_TYPE.STOPPED;
+        this.options = {
+            interval: this.DEFAULT_INTERVAL,
+            ...options
+        };
+        this.onCacheUpdates = null;
+        this.onError = null;
+    }
+
+    start() {
+        return new Promise((resolve, reject) => {
+            const workerPath = join(__dirname, 'worker.js');
+            this.worker = new Worker(workerPath, {
+                workerData: this.options
+            });
+
+            this.worker.on('message', (message) => {
+                switch (message.type) {
+                    case EVENT_TYPE.READY:
+                        this.worker.postMessage({ type: EVENT_TYPE.START });
+                        break;
+
+                    case EVENT_TYPE.STARTED:
+                        this.status = STATUS_TYPE.RUNNING;
+                        resolve();
+                        break;
+
+                    case EVENT_TYPE.STOPPED:
+                        this.status = STATUS_TYPE.STOPPED;
+                        break;
+
+                    case EVENT_TYPE.CACHE_UPDATES:
+                        if (this.onCacheUpdates) {
+                            this.onCacheUpdates(message.updates);
+                        }
+                        break;
+
+                    case EVENT_TYPE.REQUEST_CACHE_VERSION:
+                        if (this.onCacheVersionRequest) {
+                            this.onCacheVersionRequest(message.domainId);
+                        }
+                        break;
+
+                    case EVENT_TYPE.ERROR:
+                        if (this.onError) {
+                            this.onError(new Error(message.error));
+                        }
+                        break;
+                }
+            });
+
+            this.worker.on('error', (error) => {
+                this.status = STATUS_TYPE.ERROR;
+                if (this.onError) {
+                    this.onError(error);
+                }
+                reject(error);
+            });
+
+            this.worker.on('exit', (code) => {
+                const wasTerminating = this.status === STATUS_TYPE.STOPPING;
+                this.status = STATUS_TYPE.STOPPED;
+                this.worker = null;
+                
+                // Only report error if exit code is not 0 and worker wasn't being intentionally stopped
+                if (code !== 0 && !wasTerminating) {
+                    const error = new Error(`Worker stopped with exit code ${code}`);
+                    if (this.onError) {
+                        this.onError(error);
+                    }
+                }
+            });
+        });
+    }
+
+    stop() {
+        this.status = STATUS_TYPE.STOPPING;
+
+        return new Promise((resolve) => {
+            const cleanup = () => {
+                if (this.worker) {
+                    this.worker.terminate();
+                    this.worker = null;
+                }
+                this.status = STATUS_TYPE.STOPPED;
+                resolve();
+            };
+
+            // Set up listeners for graceful shutdown
+            const onMessage = (message) => {
+                if (message.type === STATUS_TYPE.STOPPED) {
+                    if (this.worker) {
+                        this.worker.off('message', onMessage);
+                    }
+                    // Give worker a moment to exit gracefully
+                    setTimeout(cleanup, 100);
+                }
+            };
+
+            this.worker.on('message', onMessage);
+
+            // Send stop message
+            this.worker.postMessage({ type: EVENT_TYPE.STOP });
+        });
+    }
+
+    getStatus() {
+        return this.status;
+    }
+
+    setOnCacheUpdates(callback) {
+        this.onCacheUpdates = callback;
+    }
+
+    setOnCacheVersionRequest(callback) {
+        this.onCacheVersionRequest = callback;
+    }
+
+    sendCacheVersionResponse(domainId, cachedVersion) {
+        if (this.worker && this.status === STATUS_TYPE.RUNNING) {
+            this.worker.postMessage({
+                type: EVENT_TYPE.CACHE_VERSION_RESPONSE,
+                domainId,
+                cachedVersion
+            });
+        }
+    }
+
+    setOnError(callback) {
+        this.onError = callback;
+    }
+}

--- a/src/helpers/cache/worker.js
+++ b/src/helpers/cache/worker.js
@@ -1,0 +1,158 @@
+import { parentPort, workerData } from 'node:worker_threads';
+import Logger from '../logger.js';
+import { CacheWorkerManager, EVENT_TYPE } from './worker-manager.js';
+
+const { interval = CacheWorkerManager.DEFAULT_INTERVAL } = workerData;
+
+let isRunning = false;
+let intervalId = null;
+let dbInitialized = false;
+let getAllDomains = null;
+
+// Initialize worker and send ready signal
+(async () => {
+    await initializeWorker();
+    if (dbInitialized) {
+        parentPort.postMessage({ type: EVENT_TYPE.READY });
+    }
+})();
+
+async function initializeWorker() {
+    try {
+        await import('../../db/mongoose.js');
+        const domainService = await import('../../services/domain.js');
+        getAllDomains = domainService.getAllDomains;
+        dbInitialized = true;
+        Logger.info('Worker database connection initialized');
+    } catch (error) {
+        Logger.error('Failed to initialize worker database connection:', error);
+        parentPort.postMessage({
+            type: EVENT_TYPE.ERROR,
+            error: `Database initialization failed: ${error.message}`
+        });
+    }
+}
+
+async function checkForUpdates() {
+    if (isRunning || !dbInitialized) {
+        return;
+    }
+    
+    isRunning = true;
+    
+    try {
+        const domains = await getAllDomains();
+        const updates = [];
+        
+        for (const domain of domains) {
+            try {
+                const cacheCheckResult = await fetchCacheVersion(domain);
+                const dbVersion = domain.lastUpdate;
+                const cachedVersion = cacheCheckResult;
+                
+                if (isCacheOutdated(cachedVersion, dbVersion)) {
+                    await updateDomainCacheSnapshot(domain, updates);
+                }
+            } catch (domainError) {
+                Logger.error(`Error processing domain ${domain._id}:`, domainError.message);
+                // Continue with next domain instead of failing completely
+            }
+        }
+        
+        if (updates.length > 0) {
+            parentPort.postMessage({
+                type: EVENT_TYPE.CACHE_UPDATES,
+                updates
+            });
+        }
+    } catch (error) {
+        Logger.error('Worker checkForUpdates error:', error);
+        parentPort.postMessage({
+            type: EVENT_TYPE.ERROR,
+            error: error.message
+        });
+    } finally {
+        isRunning = false;
+    }
+}
+
+function isCacheOutdated(cachedVersion, dbVersion) {
+    return !cachedVersion || dbVersion !== cachedVersion;
+}
+
+async function updateDomainCacheSnapshot(domain, updates) {
+    const { graphql } = await import('graphql');
+    const { domainQuery, reduceSnapshot } = await import('./query.js');
+    const schemaModule = await import('../../aggregator/schema.js');
+
+    const result = await graphql({
+        schema: schemaModule.default,
+        source: domainQuery(domain._id),
+        contextValue: { domain: domain._id }
+    });
+
+    if (result.data?.domain) {
+        updates.push({
+            domainId: domain._id.toString(),
+            data: reduceSnapshot(result.data.domain),
+            lastUpdate: domain.lastUpdate,
+            version: result.data.domain.version
+        });
+    }
+}
+
+async function fetchCacheVersion(domain) {
+    return await new Promise((resolve) => {
+        const timeout = setTimeout(() => {
+            parentPort.off('message', messageHandler);
+            resolve(null);
+        }, 1000);
+
+        const messageHandler = (message) => {
+            if (message.type === EVENT_TYPE.CACHE_VERSION_RESPONSE && message.domainId === domain._id.toString()) {
+                clearTimeout(timeout);
+                parentPort.off('message', messageHandler);
+                resolve(message.cachedVersion);
+            }
+        };
+
+        parentPort.on('message', messageHandler);
+        parentPort.postMessage({
+            type: EVENT_TYPE.REQUEST_CACHE_VERSION,
+            domainId: domain._id.toString()
+        });
+    });
+}
+
+// Handle messages from main thread
+parentPort.on('message', async (message) => {
+    try {
+        switch (message.type) {
+            case EVENT_TYPE.START:
+                if (!intervalId && dbInitialized) {
+                    intervalId = setInterval(() => checkForUpdates(), interval);
+                    parentPort.postMessage({ type: EVENT_TYPE.STARTED });
+                } else if (!dbInitialized) {
+                    parentPort.postMessage({ 
+                        type: EVENT_TYPE.ERROR, 
+                        error: 'Database not initialized' 
+                    });
+                }
+                break;
+
+            case EVENT_TYPE.STOP:
+                if (intervalId) {
+                    clearInterval(intervalId);
+                    intervalId = null;
+                }
+                parentPort.postMessage({ type: EVENT_TYPE.STOPPED });
+                break;
+        }
+    } catch (error) {
+        Logger.error('Worker message handler error:', error);
+        parentPort.postMessage({
+            type: EVENT_TYPE.ERROR,
+            error: error.message
+        });
+    }
+});

--- a/tests/unit-test/cache.test.js
+++ b/tests/unit-test/cache.test.js
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 import '../../src/db/mongoose';
 
 import { domainId, setupDatabase } from '../fixtures/db_api';
+import Domain from '../../src/models/domain';
 import Cache from '../../src/helpers/cache';
 
 let cache;
@@ -19,6 +20,10 @@ describe('Test cache', () => {
         cache = Cache.getInstance();
     });
 
+    afterEach(async () => {
+        await cache.stopScheduledUpdates();
+    });
+
     test('UNIT_SUITE - Should initialize cache', async () => {
         // test
         cache = Cache.getInstance();
@@ -32,4 +37,51 @@ describe('Test cache', () => {
         expect(cacheSingle).toBeDefined();
     });
 
+    test('UNIT_SUITE - Should initialize schduled cache update', async () => {
+        // test
+        cache = Cache.getInstance();
+        await cache.initializeCache();
+        await cache.startScheduledUpdates();
+
+        // assert
+        expect(cache.status()).toBe('running');
+    });
+
+    test('UNIT_SUITE - Should update cache when new domain version is available', async () => {
+        // test
+        cache = Cache.getInstance();
+        await cache.initializeCache();
+        await cache.startScheduledUpdates();
+
+        // assert
+        expect(cache.status()).toBe('running');
+        const domain = cache.get(domainId);
+
+        // update DB Domain version
+        await Domain.findByIdAndUpdate(domainId, { $inc: { lastUpdate: 1 } });
+        const { updatedSuccessfully, domainFromCache } = await waitForDomainUpdate(domain.version, 10, 1000);
+
+        expect(domainFromCache).toBeDefined();
+        expect(updatedSuccessfully).toBe(true);
+    }, 20000);
+
 });
+
+// Helpers
+
+async function waitForDomainUpdate(currentDomainVersion, maxAttempts, delay) {
+    let domainFromCache;
+    let attempt = 0;
+    let updatedSuccessfully = false;
+
+    while (!updatedSuccessfully && attempt < maxAttempts) {
+        await new Promise(resolve => setTimeout(resolve, delay));
+        attempt++;
+
+        domainFromCache = cache.get(domainId);
+        if (domainFromCache.version != currentDomainVersion) {
+            updatedSuccessfully = true;
+        }
+    }
+    return { updatedSuccessfully, domainFromCache };
+}


### PR DESCRIPTION
This pull request introduces a new worker-based system for scheduled cache updates in the `src/helpers/cache` module. The main goal is to offload periodic cache refresh operations to a background worker thread, improving performance and reliability. The update includes the implementation of a worker manager, the worker itself, integration into the cache class, and new unit tests to verify the functionality.

**Worker-based scheduled cache updates:**

- Added a new `CacheWorkerManager` class (`worker-manager.js`) that manages a background worker thread for periodic cache updates, including event handling, status tracking, and error management.
- Implemented a new worker script (`worker.js`) that connects to the database, checks for domain updates at a configurable interval, and communicates with the main thread to synchronize cache state.
- Integrated the worker manager into the `Cache` class (`index.js`), adding methods to start and stop scheduled updates, handle worker events, and synchronize cache versions between the worker and the main process. [[1]](diffhunk://#diff-37183324b87b89cdb9d9537a99bc1eb773757e1c0f288f19a712303828c7fbebR5-R21) [[2]](diffhunk://#diff-37183324b87b89cdb9d9537a99bc1eb773757e1c0f288f19a712303828c7fbebR33-R96)

**Testing and configuration:**

- Added and updated unit tests in `cache.test.js` to verify scheduled cache updates, cache version synchronization, and worker lifecycle management. [[1]](diffhunk://#diff-4dc0ca7529c134a6c12eaab2b7a8fe35af69e7c9a9680b22f361c4bc5eb26e23R5) [[2]](diffhunk://#diff-4dc0ca7529c134a6c12eaab2b7a8fe35af69e7c9a9680b22f361c4bc5eb26e23R23-R26) [[3]](diffhunk://#diff-4dc0ca7529c134a6c12eaab2b7a8fe35af69e7c9a9680b22f361c4bc5eb26e23R40-R87)
- Updated SonarQube configuration to exclude the new worker file from code coverage analysis.