### PR TITLE
Improved Cache Worker Manager handlers

### DIFF
--- a/src/helpers/cache/index.js
+++ b/src/helpers/cache/index.js
@@ -31,23 +31,13 @@ export default class Cache {
     }
 
     async startScheduledUpdates(options = {}) {
-        this.#workerManager = new CacheWorkerManager(options);
-        
-        this.#workerManager.setOnCacheUpdates((updates) => 
-            this.#handleCacheUpdates(updates));
-
-        this.#workerManager.setOnCacheDeletions((deletions) => 
-            this.#handleCacheDeletions(deletions));
-
-        this.#workerManager.setOnCacheVersionRequest((domainId) => 
-            this.#handleCacheVersionRequest(domainId));
-
-        this.#workerManager.setOnCachedDomainIdsRequest(() => 
-            this.#handleCachedDomainIdsRequest());
-
-        this.#workerManager.setOnError((error) => {
-            Logger.error('Cache worker error:', error);
-        });
+        this.#workerManager = new CacheWorkerManager({
+            onCacheUpdates: (updates) => this.#handleCacheUpdates(updates),
+            onCacheDeletions: (deletions) => this.#handleCacheDeletions(deletions),
+            onCacheVersionRequest: (domainId) => this.#handleCacheVersionRequest(domainId),
+            onCachedDomainIdsRequest: () => this.#handleCachedDomainIdsRequest(),
+            onError: (error) => Logger.error('Cache worker error:', error)
+        }, options);
 
         await this.#workerManager.start();
     }

--- a/src/helpers/cache/worker.js
+++ b/src/helpers/cache/worker.js
@@ -50,7 +50,7 @@ async function refreshCache() {
     isRunning = true;
     
     try {
-        const domains = await getAllDomains();
+        const domains = await getAllDomains('lastUpdate');
         const deletions = await checkForDeletions(domains);
         const updates = await checkForDomainUpdates(domains);
         
@@ -81,17 +81,13 @@ async function refreshCache() {
 async function checkForDeletions(domains) {
     const deletions = [];
     
-    try {
-        const currentDomainIds = new Set(domains.map(domain => domain._id.toString()));
-        const cachedDomainIds = await getAllCachedDomainIds();
+    const currentDomainIds = new Set(domains.map(domain => domain._id.toString()));
+    const cachedDomainIds = await getAllCachedDomainIds();
 
-        for (const cachedDomainId of cachedDomainIds) {
-            if (!currentDomainIds.has(cachedDomainId)) {
-                deletions.push(cachedDomainId);
-            }
+    for (const cachedDomainId of cachedDomainIds) {
+        if (!currentDomainIds.has(cachedDomainId)) {
+            deletions.push(cachedDomainId);
         }
-    } catch (error) {
-        Logger.error('Error checking for deletions:', error);
     }
     
     return deletions;

--- a/src/services/domain.js
+++ b/src/services/domain.js
@@ -4,6 +4,6 @@ export async function getDomainById(id) {
     return Domain.findById(id).exec();
 }
 
-export async function getAllDomains() {
-    return Domain.find().exec();
+export async function getAllDomains(select) {
+    return Domain.find().select(select).exec();
 }

--- a/tests/unit-test/cache/cache.test.js
+++ b/tests/unit-test/cache/cache.test.js
@@ -1,9 +1,9 @@
 import mongoose from 'mongoose';
-import '../../src/db/mongoose';
+import '../../../src/db/mongoose';
 
-import { domainId, setupDatabase } from '../fixtures/db_api';
-import Domain from '../../src/models/domain';
-import Cache from '../../src/helpers/cache';
+import { domainId, setupDatabase } from '../../fixtures/db_api';
+import Domain from '../../../src/models/domain';
+import Cache from '../../../src/helpers/cache';
 
 let cache;
 
@@ -24,7 +24,7 @@ describe('Test cache', () => {
         await cache.stopScheduledUpdates();
     });
 
-    test('UNIT_SUITE - Should initialize cache', async () => {
+    test('CACHE_SUITE - Should initialize cache', async () => {
         // test
         cache = Cache.getInstance();
         await cache.initializeCache();
@@ -37,7 +37,7 @@ describe('Test cache', () => {
         expect(cacheSingle).toBeDefined();
     });
 
-    test('UNIT_SUITE - Should initialize schduled cache update', async () => {
+    test('CACHE_SUITE - Should initialize schduled cache update', async () => {
         // test
         cache = Cache.getInstance();
         await cache.initializeCache();
@@ -47,7 +47,7 @@ describe('Test cache', () => {
         expect(cache.status()).toBe('running');
     });
 
-    test('UNIT_SUITE - Should update cache when new Domain version is available', async () => {
+    test('CACHE_SUITE - Should update cache when new Domain version is available', async () => {
         // test
         cache = Cache.getInstance();
         await cache.initializeCache();
@@ -65,7 +65,7 @@ describe('Test cache', () => {
         expect(updatedSuccessfully).toBe(true);
     }, 20000);
 
-    test('UNIT_SUITE - Should update cache when new Domain is created', async () => {
+    test('CACHE_SUITE - Should update cache when new Domain is created', async () => {
         // test
         cache = Cache.getInstance();
         await cache.initializeCache();
@@ -83,7 +83,7 @@ describe('Test cache', () => {
         expect(updatedSuccessfully).toBe(true);
     }, 20000);
 
-    test('UNIT_SUITE - Should update cache when Domain is deleted', async () => {
+    test('CACHE_SUITE - Should update cache when Domain is deleted', async () => {
         // test
         cache = Cache.getInstance();
         await cache.initializeCache();

--- a/tests/unit-test/cache/worker-manager.test.js
+++ b/tests/unit-test/cache/worker-manager.test.js
@@ -1,0 +1,55 @@
+import { CacheWorkerManager } from '../../../src/helpers/cache/worker-manager';
+
+describe('Test worker manager', () => {
+
+    test('CACHE_SUITE - Should start/stop worker manager', async () => {
+        const workerManager = new CacheWorkerManager({
+            onCacheUpdates: () => {},
+            onCacheDeletions: () => {},
+            onCacheVersionRequest: () => {},
+            onCachedDomainIdsRequest: () => {},
+            onError: () => {}
+        }, { interval: 500 });
+
+        // Start the worker manager
+        await workerManager.start();
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        let status = workerManager.getStatus();
+        expect(status).toBeDefined();
+        expect(status).toBe('running');
+
+        // Stop the worker manager
+        await workerManager.stop();
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        status = workerManager.getStatus();
+        expect(status).toBeDefined();
+        expect(status).toBe('stopped');
+    });
+
+    test('CACHE_SUITE - Should handle error when cache response is invalid', async () => {
+        let error = false;
+        const workerManager = new CacheWorkerManager({
+            onCacheUpdates: () => {},
+            onCacheDeletions: () => {},
+            onCacheVersionRequest: () => {},
+            onCachedDomainIdsRequest: () => badCacheResponse(workerManager),
+            onError: () => {
+                error = true;
+            }
+        }, { interval: 500 });
+
+        // Start the worker manager
+        await workerManager.start();
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // Stop the worker manager
+        await workerManager.stop();
+        expect(error).toBe(true);
+    });
+});
+
+function badCacheResponse(workerManager) {
+    workerManager.sendCachedDomainIdsResponse(null);
+}


### PR DESCRIPTION
This pull request refactors the cache worker management system to simplify event handling and improve test coverage. The main changes include replacing setter methods for event handlers with a constructor-based approach, cleaning up redundant error handling, and updating related tests and service functions.

**Cache Worker Manager Refactor:**

* Replaced individual setter methods for event handlers (`setOnCacheUpdates`, `setOnCacheDeletions`, etc.) in `CacheWorkerManager` with a single constructor parameter that takes all event handlers as an object, simplifying initialization and usage. (`src/helpers/cache/worker-manager.js`, `src/helpers/cache/index.js`) [[1]](diffhunk://#diff-6e3c19ddde81000620e4b6a7d74df8d21857984596279b36cfa3a955b93edb81L33-R41) [[2]](diffhunk://#diff-37183324b87b89cdb9d9537a99bc1eb773757e1c0f288f19a712303828c7fbebL34-R40) [[3]](diffhunk://#diff-6e3c19ddde81000620e4b6a7d74df8d21857984596279b36cfa3a955b93edb81L159-L174) [[4]](diffhunk://#diff-6e3c19ddde81000620e4b6a7d74df8d21857984596279b36cfa3a955b93edb81L193-L196)
* Removed redundant checks for handler existence before invocation, since all handlers are now required at construction. (`src/helpers/cache/worker-manager.js`)
* Simplified error handling in the worker manager by removing unnecessary error event logic and redundant promise rejection. (`src/helpers/cache/worker-manager.js`)
* Adjusted the worker manager's status update logic in the `stop` method for clarity. (`src/helpers/cache/worker-manager.js`)

**Domain Service and Worker Updates:**

* Updated `getAllDomains` in `domain.js` to accept a `select` parameter for more efficient queries, and applied this in the worker to only fetch the `lastUpdate` field when refreshing the cache. (`src/services/domain.js`, `src/helpers/cache/worker.js`) [[1]](diffhunk://#diff-069bd8c92d9f4b4daf862ec0e5641b3beeca18ecd951ebd83c5a5ea3b3cd3715L7-R8) [[2]](diffhunk://#diff-bcdb06a239785b5ef4e0730f630ad1d531dc86adac18557215590eda9a05ac59L53-R53)
* Cleaned up error handling in `checkForDeletions` by removing unnecessary try/catch blocks. (`src/helpers/cache/worker.js`) [[1]](diffhunk://#diff-bcdb06a239785b5ef4e0730f630ad1d531dc86adac18557215590eda9a05ac59L84) [[2]](diffhunk://#diff-bcdb06a239785b5ef4e0730f630ad1d531dc86adac18557215590eda9a05ac59L93-L95)

**Testing Improvements:**

* Added a new unit test file `worker-manager.test.js` to test the lifecycle and error handling of `CacheWorkerManager`. (`tests/unit-test/cache/worker-manager.test.js`)
* Renamed and updated the cache tests to use consistent import paths and suite names, improving clarity and maintainability. (`tests/unit-test/cache/cache.test.js`) [[1]](diffhunk://#diff-c3edc3ee46bc0a5684ade540980467a0597d65508861da14f51287d1b674bc7dL2-R6) [[2]](diffhunk://#diff-c3edc3ee46bc0a5684ade540980467a0597d65508861da14f51287d1b674bc7dL27-R27) [[3]](diffhunk://#diff-c3edc3ee46bc0a5684ade540980467a0597d65508861da14f51287d1b674bc7dL40-R40) [[4]](diffhunk://#diff-c3edc3ee46bc0a5684ade540980467a0597d65508861da14f51287d1b674bc7dL50-R50) [[5]](diffhunk://#diff-c3edc3ee46bc0a5684ade540980467a0597d65508861da14f51287d1b674bc7dL68-R68) [[6]](diffhunk://#diff-c3edc3ee46bc0a5684ade540980467a0597d65508861da14f51287d1b674bc7dL86-R86)