### PR TITLE
patch: NoSQL vulnerability introduced by GraphQL resolvers

### DIFF
--- a/src/aggregator/configuration-type.js
+++ b/src/aggregator/configuration-type.js
@@ -159,7 +159,7 @@ export const configType = new GraphQLObjectType({
                 }
             },
             resolve: async (source, { _id, strategy, operation, activated }, context) => {
-                return resolveConfigStrategy(source, _id, strategy, operation, activated, context);
+                return resolveConfigStrategy(source, _id?.toString(), strategy?.toString(), operation?.toString(), activated, context);
             }
         },
         components: {
@@ -201,7 +201,7 @@ export const groupConfigType = new GraphQLObjectType({
                 }
             },
             resolve: async (source, { _id, key, activated }, context) => {
-                return resolveConfig(source, _id, key, activated, context);
+                return resolveConfig(source, _id?.toString(), key?.toString(), activated, context);
             }
         }
     }
@@ -241,7 +241,7 @@ export const domainType = new GraphQLObjectType({
                 }
             },
             resolve: async (source, { _id, name, activated }, context) => {
-                return resolveGroupConfig(source, _id, name, activated, context);
+                return resolveGroupConfig(source, _id?.toString(), name?.toString(), activated, context);
             }
         }
     }

--- a/src/aggregator/resolvers.js
+++ b/src/aggregator/resolvers.js
@@ -1,7 +1,8 @@
+import { Types } from 'mongoose';
 import Domain from '../models/domain.js';
 import GroupConfig from '../models/group-config.js';
 import { Config} from '../models/config.js';
-import { ConfigStrategy } from '../models/config-strategy.js';
+import { ConfigStrategy, OperationsType, StrategiesType } from '../models/config-strategy.js';
 import Component from '../models/component.js';
 
 export const resolveConfigByKey = async (domain, key) => Config.findOne({ domain, key }, null, { lean: true });
@@ -22,9 +23,9 @@ export function resolveEnvValue(source, field, keys) {
 export async function resolveConfigStrategy(source, _id, strategy, operation, activated, context) {
     const args = {};
 
-    if (_id) { args._id = _id; }
-    if (strategy) { args.strategy = strategy; }
-    if (operation) { args.operation = operation; }
+    if (_id) { args._id = new Types.ObjectId(_id.toString()); }
+    if (strategy) { args.strategy = Object.values(StrategiesType).find(t => t === strategy); }
+    if (operation) { args.operation = Object.values(OperationsType).find(t => t === operation); }
     
     let strategies = await ConfigStrategy.find({ config: source._id, ...args }).lean().exec();
     const environment = context.environment;
@@ -57,8 +58,8 @@ export async function resolveRelay(source, context) {
 export async function resolveConfig(source, _id, key, activated, context) {
     const args = {};
 
-    if (_id) { args._id = _id; }
-    if (key) { args.key = key; }
+    if (_id) { args._id = new Types.ObjectId(_id.toString()); }
+    if (key) { args.key = key.toString(); }
     if (context._component) { args.components = context._component; }
 
     let configs = await Config.find({ group: source._id, ...args }).lean().exec();
@@ -73,8 +74,8 @@ export async function resolveConfig(source, _id, key, activated, context) {
 export async function resolveGroupConfig(source, _id, name, activated, context) {
     const args = {};
 
-    if (_id) { args._id = _id; }
-    if (name) { args.name = name; }
+    if (_id) { args._id = new Types.ObjectId(_id.toString()); }
+    if (name) { args.name = name.toString(); }
 
     let groups = await GroupConfig.find({ domain: source._id, ...args }).lean().exec();
 


### PR DESCRIPTION
This pull request improves type safety and consistency in the resolver functions and GraphQL type definitions for configuration-related queries. The main changes ensure that IDs and enum values are properly converted to the expected types before being used in MongoDB queries, reducing the risk of runtime errors and improving code reliability.

**Type handling and consistency improvements:**

- All `_id` arguments are now explicitly converted to strings and then to `Types.ObjectId` before being used in queries, ensuring correct MongoDB ID handling. [[1]](diffhunk://#diff-91383c0c3e247c85643b06370fc5b5303bd07c25a6e3399491def8b753ff1fbfL162-R162) [[2]](diffhunk://#diff-91383c0c3e247c85643b06370fc5b5303bd07c25a6e3399491def8b753ff1fbfL204-R204) [[3]](diffhunk://#diff-91383c0c3e247c85643b06370fc5b5303bd07c25a6e3399491def8b753ff1fbfL244-R244) [[4]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL25-R28) [[5]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL60-R62) [[6]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL76-R78)
- `strategy`, `operation`, `key`, and `name` arguments are now converted to strings and validated against their respective enum types (`StrategiesType`, `OperationsType`) where applicable, ensuring only valid values are used in queries. [[1]](diffhunk://#diff-91383c0c3e247c85643b06370fc5b5303bd07c25a6e3399491def8b753ff1fbfL162-R162) [[2]](diffhunk://#diff-91383c0c3e247c85643b06370fc5b5303bd07c25a6e3399491def8b753ff1fbfL204-R204) [[3]](diffhunk://#diff-91383c0c3e247c85643b06370fc5b5303bd07c25a6e3399491def8b753ff1fbfL244-R244) [[4]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL25-R28) [[5]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL60-R62) [[6]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL76-R78)

**Codebase maintenance:**

- Added missing imports for `Types`, `OperationsType`, and `StrategiesType` in `src/aggregator/resolvers.js` to support the new type handling logic.