### PR TITLE
feat: harnessed Cache to GraphQL criteria evaluation flow

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14,7 +14,7 @@
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "express-basic-auth": "^1.2.1",
-        "express-rate-limit": "^8.4.1",
+        "express-rate-limit": "^8.5.0",
         "express-validator": "^7.3.2",
         "graphql": "^16.13.2",
         "graphql-http": "^1.22.4",
@@ -1376,9 +1376,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3235,9 +3235,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
+      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "express-basic-auth": "^1.2.1",
-    "express-rate-limit": "^8.4.1",
+    "express-rate-limit": "^8.5.0",
     "express-validator": "^7.3.2",
     "graphql": "^16.13.2",
     "graphql-http": "^1.22.4",

--- a/src/aggregator/resolvers.js
+++ b/src/aggregator/resolvers.js
@@ -4,8 +4,17 @@ import GroupConfig from '../models/group-config.js';
 import { Config} from '../models/config.js';
 import { ConfigStrategy, OperationsType, StrategiesType } from '../models/config-strategy.js';
 import Component from '../models/component.js';
+import Cache from '../helpers/cache/index.js';
+import { getConfigFromCache } from '../services/snapshot-cache.js';
 
-export const resolveConfigByKey = async (domain, key) => Config.findOne({ domain, key }, null, { lean: true });
+export async function resolveConfigByKey(domain, key) {
+    const cache = Cache.getInstance();
+    if (cache.isEnabled()) {
+        return getConfigFromCache(cache, domain, key);
+    }
+    
+    return Config.findOne({ domain, key }, null, { lean: true });
+}
 
 export function resolveEnvValue(source, field, keys) {
     const arrValue = [];

--- a/tests/client-api-cached.test.js
+++ b/tests/client-api-cached.test.js
@@ -196,6 +196,8 @@ describe('Testing criteria [GraphQL]', () => {
 
     test('CLIENT_CACHED_SUITE - It will be deactivated on default environment', async () => {
         await changeConfigStatus(configId, false, EnvType.DEFAULT);
+        await Cache.getInstance().refreshDomain(domainId);
+
         const response = await request(app)
             .post('/graphql')
             .set('Authorization', `Bearer ${token}`)
@@ -222,6 +224,8 @@ describe('Testing criteria [GraphQL]', () => {
         qaToken = responseToken.body.token;
 
         await changeConfigStatus(configId, true, 'QA');
+        await Cache.getInstance().refreshDomain(domainId);
+
         const response = await request(app)
             .post('/graphql')
             .set('Authorization', `Bearer ${qaToken}`)


### PR DESCRIPTION
This pull request introduces improvements to configuration retrieval and caching mechanisms, as well as updates dependencies and enhances test reliability. The main focus is on optimizing how configuration data is fetched by leveraging caching, and ensuring tests reflect cache state changes.

**Caching and configuration retrieval improvements:**

* Refactored `resolveConfigByKey` in `src/aggregator/resolvers.js` to first attempt fetching configuration from cache using `getConfigFromCache` if caching is enabled, falling back to a database query otherwise. This improves performance and reduces database load.

**Testing reliability and cache consistency:**

* Updated tests in `tests/client-api-cached.test.js` to explicitly refresh the domain cache after changing configuration status, ensuring that test results are consistent with the latest cache state. [[1]](diffhunk://#diff-db08494f97eb56f3c5c061c24b868515593472890e1f306649b4ca2937471b89R199-R200) [[2]](diffhunk://#diff-db08494f97eb56f3c5c061c24b868515593472890e1f306649b4ca2937471b89R227-R228)

**Dependency updates:**

* Upgraded the `express-rate-limit` package from version `8.4.1` to `8.5.0` in `package.json` to incorporate the latest fixes and features.